### PR TITLE
Handle Sub Overflow Edge Case

### DIFF
--- a/src/value/arithmetic.rs
+++ b/src/value/arithmetic.rs
@@ -400,28 +400,10 @@ mod tests {
     #[test]
     fn sub_overflow_promotes_to_signed_or_float() {
         // ------------------------------------------------------------------------
-        // -- sub overflow u64 bounds, result should promote to SignedBigInt
-        // ------------------------------------------------------------------------
-        let left: Value = u64::MIN.into();
-        let right: Value = u64::MAX.into();
-        let result = left - right;
-        let expected_order = Order::SignedBigInt;
-        assert_eq!(
-            result.order(),
-            expected_order,
-            "sub overflow should promote this to {expected_order:?} : got = {result:?}"
-        );
-        let expected_value = (-18446744073709551615_i128).into();
-        assert_eq!(
-            result, expected_value,
-            "sub overflow value should be {expected_value:?} : got = {result:?}"
-        );
-
-        // ------------------------------------------------------------------------
         // -- sub overflow i64 bounds, result should promote to SignedBigInt
         // ------------------------------------------------------------------------
-        let left: Value = i64::MIN.into();
-        let right: Value = i64::MAX.into();
+        let left: Value = 0_i64.into();
+        let right: Value = i64::MIN.into();
         let result = left - right;
         let expected_order = Order::SignedBigInt;
         assert_eq!(
@@ -429,25 +411,7 @@ mod tests {
             expected_order,
             "sub overflow should promote this to {expected_order:?} : got = {result:?}"
         );
-        let expected_value = (-18446744073709551615_i128).into();
-        assert_eq!(
-            result, expected_value,
-            "sub overflow value should be {expected_value:?} : got = {result:?}"
-        );
-
-        // ------------------------------------------------------------------------
-        // -- sub overflow u128 bounds, result should promote to Float
-        // ------------------------------------------------------------------------
-        let left: Value = u128::MIN.into();
-        let right: Value = u128::MAX.into();
-        let result = left - right;
-        let expected_order = Order::Float;
-        assert_eq!(
-            result.order(),
-            expected_order,
-            "sub overflow should promote this to {expected_order:?} : got = {result:?}"
-        );
-        let expected_value = (-3.402823669209385e38).into();
+        let expected_value = (9223372036854775808_i128).into();
         assert_eq!(
             result, expected_value,
             "sub overflow value should be {expected_value:?} : got = {result:?}"
@@ -456,8 +420,8 @@ mod tests {
         // ------------------------------------------------------------------------
         // -- sub overflow i128 bounds, result should promote to Float
         // ------------------------------------------------------------------------
-        let left: Value = i128::MIN.into();
-        let right: Value = i128::MAX.into();
+        let left: Value = 0_i128.into();
+        let right: Value = i128::MIN.into();
         let result = left - right;
         let expected_order = Order::Float;
         assert_eq!(
@@ -465,7 +429,7 @@ mod tests {
             expected_order,
             "sub overflow should promote this to {expected_order:?} : got = {result:?}"
         );
-        let expected_value = (-3.402823669209385e38).into();
+        let expected_value = (1.7014118346046923e38).into();
         assert_eq!(
             result, expected_value,
             "sub overflow value should be {expected_value:?} : got = {result:?}"

--- a/src/value/arithmetic.rs
+++ b/src/value/arithmetic.rs
@@ -397,42 +397,28 @@ mod tests {
         assert_eq!(result, (-1_i64).into());
     }
 
-    #[test]
-    fn sub_overflow_promotes_to_signed_or_float() {
-        // ------------------------------------------------------------------------
-        // -- sub overflow i64 bounds, result should promote to SignedBigInt
-        // ------------------------------------------------------------------------
-        let left: Value = 0_i64.into();
-        let right: Value = i64::MIN.into();
+    #[rstest]
+    #[case::i64_overflows_to_i128(0_i64, i64::MIN, Order::SignedBigInt, 9223372036854775808_i128)]
+    #[case::i128_overflows_to_float(0_i128, i128::MIN, Order::Float, 1.7014118346046923e38)]
+    fn sub_overflow_promotes_to_signed_or_float(
+        #[case] left: impl Into<Value>,
+        #[case] right: impl Into<Value>,
+        #[case] expected_order: Order,
+        #[case] expected_value: impl Into<Value>,
+    ) {
+        let left = left.into();
+        let right = right.into();
         let result = left - right;
-        let expected_order = Order::SignedBigInt;
-        assert_eq!(
-            result.order(),
-            expected_order,
-            "sub overflow should promote this to {expected_order:?} : got = {result:?}"
-        );
-        let expected_value = (9223372036854775808_i128).into();
-        assert_eq!(
-            result, expected_value,
-            "sub overflow value should be {expected_value:?} : got = {result:?}"
-        );
 
-        // ------------------------------------------------------------------------
-        // -- sub overflow i128 bounds, result should promote to Float
-        // ------------------------------------------------------------------------
-        let left: Value = 0_i128.into();
-        let right: Value = i128::MIN.into();
-        let result = left - right;
-        let expected_order = Order::Float;
         assert_eq!(
             result.order(),
             expected_order,
             "sub overflow should promote this to {expected_order:?} : got = {result:?}"
         );
-        let expected_value = (1.7014118346046923e38).into();
+        let expected_value = expected_value.into();
         assert_eq!(
             result, expected_value,
-            "sub overflow value should be {expected_value:?} : got = {result:?}"
+            "sub overflow value should be {expected_value:?} : got = {result:?}",
         );
     }
 

--- a/src/value/arithmetic.rs
+++ b/src/value/arithmetic.rs
@@ -14,6 +14,17 @@ impl CheckedAdd for f64 {
     }
 }
 
+// shim for the missing method on f64
+trait CheckedSub: Sized + ops::Sub<Output = Self> {
+    fn checked_sub(self, rhs: Self) -> Option<Self>;
+}
+
+impl CheckedSub for f64 {
+    fn checked_sub(self, rhs: Self) -> Option<Self> {
+        Some(self - rhs)
+    }
+}
+
 impl<Rhs> ops::AddAssign<Rhs> for Value
 where
     Rhs: Into<Value>,
@@ -48,7 +59,11 @@ where
         if rhs > *self {
             self.promote_to_signed();
         }
-        dispatch_operation!(self, rhs, n, |rhs| *n -= rhs);
+        *self = dispatch_operation!(self, rhs, n, |rhs| (*n).checked_sub(rhs).map(Value::from))
+            .unwrap_or_else(|| {
+                self.promote();
+                dispatch_operation!(self, rhs, n, |rhs| Value::from(*n - rhs))
+            })
     }
 }
 
@@ -380,6 +395,81 @@ mod tests {
             Value::SignedInt(_) | Value::SignedBigInt(_)
         ));
         assert_eq!(result, (-1_i64).into());
+    }
+
+    #[test]
+    fn sub_overflow_promotes_to_signed_or_float() {
+        // ------------------------------------------------------------------------
+        // -- sub overflow u64 bounds, result should promote to SignedBigInt
+        // ------------------------------------------------------------------------
+        let left: Value = u64::MIN.into();
+        let right: Value = u64::MAX.into();
+        let result = left - right;
+        let expected_order = Order::SignedBigInt;
+        assert_eq!(
+            result.order(),
+            expected_order,
+            "sub overflow should promote this to {expected_order:?} : got = {result:?}"
+        );
+        let expected_value = (-18446744073709551615_i128).into();
+        assert_eq!(
+            result, expected_value,
+            "sub overflow value should be {expected_value:?} : got = {result:?}"
+        );
+
+        // ------------------------------------------------------------------------
+        // -- sub overflow i64 bounds, result should promote to SignedBigInt
+        // ------------------------------------------------------------------------
+        let left: Value = i64::MIN.into();
+        let right: Value = i64::MAX.into();
+        let result = left - right;
+        let expected_order = Order::SignedBigInt;
+        assert_eq!(
+            result.order(),
+            expected_order,
+            "sub overflow should promote this to {expected_order:?} : got = {result:?}"
+        );
+        let expected_value = (-18446744073709551615_i128).into();
+        assert_eq!(
+            result, expected_value,
+            "sub overflow value should be {expected_value:?} : got = {result:?}"
+        );
+
+        // ------------------------------------------------------------------------
+        // -- sub overflow u128 bounds, result should promote to Float
+        // ------------------------------------------------------------------------
+        let left: Value = u128::MIN.into();
+        let right: Value = u128::MAX.into();
+        let result = left - right;
+        let expected_order = Order::Float;
+        assert_eq!(
+            result.order(),
+            expected_order,
+            "sub overflow should promote this to {expected_order:?} : got = {result:?}"
+        );
+        let expected_value = (-3.402823669209385e38).into();
+        assert_eq!(
+            result, expected_value,
+            "sub overflow value should be {expected_value:?} : got = {result:?}"
+        );
+
+        // ------------------------------------------------------------------------
+        // -- sub overflow i128 bounds, result should promote to Float
+        // ------------------------------------------------------------------------
+        let left: Value = i128::MIN.into();
+        let right: Value = i128::MAX.into();
+        let result = left - right;
+        let expected_order = Order::Float;
+        assert_eq!(
+            result.order(),
+            expected_order,
+            "sub overflow should promote this to {expected_order:?} : got = {result:?}"
+        );
+        let expected_value = (-3.402823669209385e38).into();
+        assert_eq!(
+            result, expected_value,
+            "sub overflow value should be {expected_value:?} : got = {result:?}"
+        );
     }
 
     // ---------- INFINITY PROPAGATION ----------


### PR DESCRIPTION
Hello! Thank you for this amazing library!!  

# The Issue

When trying to do something like `Value::SignedInt(0) - Value::SignedInt(i64::MIN)` I would receive a panic : `attempt to subtract with overflow`.

As far as I could tell, sub-underflow was accounted for, but not sub-overflow. However, it is entirely possible I overlooked something and this PR is incorrect.

# The Fix

I created another shim for `f64`, `CheckedSub`:

```rust
// shim for the missing method on f64
trait CheckedSub: Sized + ops::Sub<Output = Self> {
    fn checked_sub(self, rhs: Self) -> Option<Self>;
}

impl CheckedSub for f64 {
    fn checked_sub(self, rhs: Self) -> Option<Self> {
        Some(self - rhs)
    }
}
```

and mirrored the `AddAssign` implementation:

```rust
impl<Rhs> ops::SubAssign<Rhs> for Value
where
    Rhs: Into<Value>,
{
    fn sub_assign(&mut self, rhs: Rhs) {
        let mut rhs = rhs.into();
        if rhs > *self {
            self.promote_to_signed();
        }
        *self = dispatch_operation!(self, rhs, n, |rhs| (*n).checked_sub(rhs).map(Value::from))
            .unwrap_or_else(|| {
                self.promote();
                dispatch_operation!(self, rhs, n, |rhs| Value::from(*n - rhs))
            })
    }
}
```

I also added edge case tests:

<details>
  <summary>Click to show test</summary>

```rust
#[test]
fn sub_overflow_promotes_to_signed_or_float() {
    // ------------------------------------------------------------------------
    // -- sub overflow i64 bounds, result should promote to SignedBigInt
    // ------------------------------------------------------------------------
    let left: Value = 0_i64.into();
    let right: Value = i64::MIN.into();
    let result = left - right;
    let expected_order = Order::SignedBigInt;
    assert_eq!(
        result.order(),
        expected_order,
        "sub overflow should promote this to {expected_order:?} : got = {result:?}"
    );
    let expected_value = (9223372036854775808_i128).into();
    assert_eq!(
        result, expected_value,
        "sub overflow value should be {expected_value:?} : got = {result:?}"
    );

    // ------------------------------------------------------------------------
    // -- sub overflow i128 bounds, result should promote to Float
    // ------------------------------------------------------------------------
    let left: Value = 0_i128.into();
    let right: Value = i128::MIN.into();
    let result = left - right;
    let expected_order = Order::Float;
    assert_eq!(
        result.order(),
        expected_order,
        "sub overflow should promote this to {expected_order:?} : got = {result:?}"
    );
    let expected_value = (1.7014118346046923e38).into();
    assert_eq!(
        result, expected_value,
        "sub overflow value should be {expected_value:?} : got = {result:?}"
    );
}
```

</details>

Now sub-overflow and promotion of the result seem to be working as expected.

Please let me know if you have any questions or concerns!