### PR TITLE
Overflow promotion fix

### DIFF
--- a/src/value/arithmetic.rs
+++ b/src/value/arithmetic.rs
@@ -4,24 +4,39 @@ use super::dispatch_operation;
 use crate::Value;
 
 // shim for the missing method on f64
-trait CheckedAdd: Sized + ops::Add<Output = Self> {
+trait CheckedMaths:
+    Sized
+    + ops::Add<Output = Self>
+    + ops::Sub<Output = Self>
+    + ops::Div<Output = Self>
+    + ops::Rem<Output = Self>
+{
     fn checked_add(self, rhs: Self) -> Option<Self>;
+    fn checked_sub(self, rhs: Self) -> Option<Self>;
+    fn checked_div(self, rhs: Self) -> Option<Self>;
+    fn checked_mul(self, rhs: Self) -> Option<Self>;
+    fn checked_rem(self, rhs: Self) -> Option<Self>;
 }
 
-impl CheckedAdd for f64 {
+impl CheckedMaths for f64 {
     fn checked_add(self, rhs: Self) -> Option<Self> {
         Some(self + rhs)
     }
-}
 
-// shim for the missing method on f64
-trait CheckedSub: Sized + ops::Sub<Output = Self> {
-    fn checked_sub(self, rhs: Self) -> Option<Self>;
-}
-
-impl CheckedSub for f64 {
     fn checked_sub(self, rhs: Self) -> Option<Self> {
         Some(self - rhs)
+    }
+
+    fn checked_div(self, rhs: Self) -> Option<Self> {
+        Some(self / rhs)
+    }
+
+    fn checked_mul(self, rhs: Self) -> Option<Self> {
+        Some(self * rhs)
+    }
+
+    fn checked_rem(self, rhs: Self) -> Option<Self> {
+        Some(self % rhs)
     }
 }
 
@@ -85,7 +100,11 @@ where
 {
     fn mul_assign(&mut self, rhs: Rhs) {
         let mut rhs = rhs.into();
-        dispatch_operation!(self, rhs, n, |rhs| *n *= rhs);
+        *self = dispatch_operation!(self, rhs, n, |rhs| (*n).checked_mul(rhs).map(Value::from))
+            .unwrap_or_else(|| {
+                self.promote();
+                dispatch_operation!(self, rhs, n, |rhs| Value::from(*n * rhs))
+            });
     }
 }
 
@@ -109,7 +128,11 @@ where
         self.promote_to_float();
         let mut rhs = rhs.into();
         rhs.promote_to_float();
-        dispatch_operation!(self, rhs, n, |rhs| *n /= rhs);
+        *self = dispatch_operation!(self, rhs, n, |rhs| (*n).checked_div(rhs).map(Value::from))
+            .unwrap_or_else(|| {
+                self.promote();
+                dispatch_operation!(self, rhs, n, |rhs| Value::from(*n / rhs))
+            });
     }
 }
 
@@ -131,7 +154,11 @@ where
 {
     fn rem_assign(&mut self, rhs: Rhs) {
         let mut rhs = rhs.into();
-        dispatch_operation!(self, rhs, n, |rhs| *n %= rhs);
+        *self = dispatch_operation!(self, rhs, n, |rhs| (*n).checked_rem(rhs).map(Value::from))
+            .unwrap_or_else(|| {
+                self.promote();
+                dispatch_operation!(self, rhs, n, |rhs| Value::from(*n % rhs))
+            });
     }
 }
 
@@ -419,6 +446,88 @@ mod tests {
         assert_eq!(
             result, expected_value,
             "sub overflow value should be {expected_value:?} : got = {result:?}",
+        );
+    }
+
+    #[rstest]
+    #[case::i64_overflows_to_i128(
+        i64::MAX,
+        i64::MAX,
+        Order::SignedBigInt,
+        85070591730234615847396907784232501249_i128
+    )]
+    #[case::i128_overflows_to_float(i128::MAX, i128::MAX, Order::Float, 2.894802230932905e76)]
+    fn mul_overflow_promotes_to_signed_or_float(
+        #[case] left: impl Into<Value>,
+        #[case] right: impl Into<Value>,
+        #[case] expected_order: Order,
+        #[case] expected_value: impl Into<Value>,
+    ) {
+        let left = left.into();
+        let right = right.into();
+        let result = left * right;
+
+        assert_eq!(
+            result.order(),
+            expected_order,
+            "mul overflow should promote this to {expected_order:?} : got = {result:?}"
+        );
+        let expected_value = expected_value.into();
+        assert_eq!(
+            result, expected_value,
+            "mul overflow value should be {expected_value:?} : got = {result:?}",
+        );
+    }
+
+    #[rstest]
+    #[case::i64_overflows_to_float(i64::MIN, -1_i64, 9.223372036854776e18)]
+    #[case::i128_overflows_to_float(i128::MIN, -1_i128, 1.7014118346046923e38)]
+    fn div_overflow_promotes_to_float(
+        #[case] left: impl Into<Value>,
+        #[case] right: impl Into<Value>,
+        #[case] expected_value: impl Into<Value>,
+    ) {
+        let left = left.into();
+        let right = right.into();
+        let result = left / right;
+
+        // Div always produces a float
+        let expected_order = Order::Float;
+
+        assert_eq!(
+            result.order(),
+            expected_order,
+            "div overflow should promote this to {expected_order:?} : got = {result:?}"
+        );
+        let expected_value = expected_value.into();
+        assert_eq!(
+            result, expected_value,
+            "sub overflow value should be {expected_value:?} : got = {result:?}",
+        );
+    }
+
+    #[rstest]
+    #[case::i64_overflows_to_i128(i64::MIN, -1_i64, Order::SignedBigInt, 0_u128)]
+    #[case::i128_overflows_to_float(i128::MIN, -1_i128, Order::Float, -0.0)]
+    fn rem_overflow_promotes_to_signed_or_float(
+        #[case] left: impl Into<Value>,
+        #[case] right: impl Into<Value>,
+        #[case] expected_order: Order,
+        #[case] expected_value: impl Into<Value>,
+    ) {
+        let left = left.into();
+        let right = right.into();
+        let result = left % right;
+
+        assert_eq!(
+            result.order(),
+            expected_order,
+            "rem overflow should promote this to {expected_order:?} : got = {result:?}"
+        );
+        let expected_value = expected_value.into();
+        assert_eq!(
+            result, expected_value,
+            "rem overflow value should be {expected_value:?} : got = {result:?}",
         );
     }
 

--- a/src/value/arithmetic.rs
+++ b/src/value/arithmetic.rs
@@ -9,6 +9,7 @@ trait CheckedMaths:
     + ops::Add<Output = Self>
     + ops::Sub<Output = Self>
     + ops::Div<Output = Self>
+    + ops::Mul<Output = Self>
     + ops::Rem<Output = Self>
 {
     fn checked_add(self, rhs: Self) -> Option<Self>;

--- a/src/value/arithmetic.rs
+++ b/src/value/arithmetic.rs
@@ -503,7 +503,7 @@ mod tests {
         let expected_value = expected_value.into();
         assert_eq!(
             result, expected_value,
-            "sub overflow value should be {expected_value:?} : got = {result:?}",
+            "div overflow value should be {expected_value:?} : got = {result:?}",
         );
     }
 


### PR DESCRIPTION
PR that was mentioned earlier today..

I went ahead and combined the `checked_*` methods into a single trait, `CheckedMaths`, which seemed "cleaner" to me. If you do not like this, I have no problem changing it back to one trait per `checked_*` method.

<details>
  <summary>Click to view <code>CheckedMaths</code> trait</summary>

```rust
// shim for the missing method on f64
trait CheckedMaths:
    Sized
    + ops::Add<Output = Self>
    + ops::Sub<Output = Self>
    + ops::Div<Output = Self>
    + ops::Mul<Output = Self>
    + ops::Rem<Output = Self>
{
    fn checked_add(self, rhs: Self) -> Option<Self>;
    fn checked_sub(self, rhs: Self) -> Option<Self>;
    fn checked_div(self, rhs: Self) -> Option<Self>;
    fn checked_mul(self, rhs: Self) -> Option<Self>;
    fn checked_rem(self, rhs: Self) -> Option<Self>;
}

impl CheckedMaths for f64 {
    fn checked_add(self, rhs: Self) -> Option<Self> {
        Some(self + rhs)
    }

    fn checked_sub(self, rhs: Self) -> Option<Self> {
        Some(self - rhs)
    }

    fn checked_div(self, rhs: Self) -> Option<Self> {
        Some(self / rhs)
    }

    fn checked_mul(self, rhs: Self) -> Option<Self> {
        Some(self * rhs)
    }

    fn checked_rem(self, rhs: Self) -> Option<Self> {
        Some(self % rhs)
    }
}
```

</details>

---

# Separate Concern

## TLDR

<details>
  <summary>Click to view TLDR demo</summary>

```rust
println!("\t=============== RAW VALUES ==============\n");
println!("i128::MAX = {}", i128::MAX);
let a = i128::MAX as f64;
println!("i128::MAX as f64 = {a:e} [no fmt] = {a}");
println!("\n\t============== CONVERSION TO f64 PRIOR TO DIVISION ==============\n");
println!("i128::MAX / 2 = {}", i128::MAX / 2);
let b = (i128::MAX as f64) / 2.0;
println!("(i128::MAX as f64) / 2.0 = {b:e} [no fmt] = {b} <-- precision is lost!");
println!("\n\t============== CONVERSION FROM f64 BACK INTO i128 ==============\n");
let c = b as i128;
println!("((i128::MAX as f64) / 2.0) as i128 = {c:e} [no fmt] = {c} <-- loss of precision reflected");

//        =============== RAW VALUES ==============
//
// i128::MAX = 170141183460469231731687303715884105727
// i128::MAX as f64 = 1.7014118346046923e38 [no fmt] = 170141183460469230000000000000000000000
//
//        ============== CONVERSION TO f64 PRIOR TO DIVISION ==============
//
// i128::MAX / 2 = 85070591730234615865843651857942052863
// (i128::MAX as f64) / 2.0 = 8.507059173023462e37 [no fmt] = 85070591730234620000000000000000000000 <-- precision is lost!
//
//        ============== CONVERSION FROM f64 BACK INTO i128 ==============
//
// ((i128::MAX as f64) / 2.0) as i128 = 8.5070591730234615865843651857942052864e37 [no fmt] = 85070591730234615865843651857942052864 <-- loss of precision reflected
```

</details>

## Extended Explanation

Also, I noticed the existing implementation of `DivAssign` causes issues with `trunc_div`.

For example, notice the last digit (3 vs 4):

```rust
println!("{}", i128::MAX / 2); 
//-> 85070591730234615865843651857942052863
println!("{:?}", Value::SignedBigInt(i128::MAX).trunc_div(2)); 
//-> UnsignedBigInt(85070591730234615865843651857942052864)
```

I could be wrong, but I believe this is because the `DivAssign` implementation promotes to float prior to dividing, which causes the `i128::MAX` to lose some precision, thus producing an incorrect answer.

Implementation of `DivAssign` for reference:

FYI - this is the new implementation, but the same issue exists in the old implementation as well - this change is not what caused the issue.

<details>
  <summary>Click to view DivAssign</summary>

```rust
impl<Rhs> ops::DivAssign<Rhs> for Value
where
    Rhs: Into<Value>,
{
    fn div_assign(&mut self, rhs: Rhs) {
        self.promote_to_float();
        let mut rhs = rhs.into();
        rhs.promote_to_float();
        *self = dispatch_operation!(self, rhs, n, |rhs| (*n).checked_div(rhs).map(Value::from))
            .unwrap_or_else(|| {
                self.promote();
                dispatch_operation!(self, rhs, n, |rhs| Value::from(*n / rhs))
            });
    }
}
```

</details>

Changing the implementation to the code below solves the issue described above. 

- I didn't want to make this change because I saw comments mentioning that divison always produces a float
- This change would mean all division would follow the same promotion rules as the `AddAssign`/`SubAssign`/`MulAssign`/`RemAssign` implementations
- This change also causes a bunch of tests to fail for the same promotional reason (not all divison would produce a float)

<details>
  <summary>Click to view DivAssign fix</summary>

```rust
impl<Rhs> ops::DivAssign<Rhs> for Value
where
    Rhs: Into<Value>,
{
    fn div_assign(&mut self, rhs: Rhs) {
        let mut rhs = rhs.into();
        *self = dispatch_operation!(self, rhs, n, |rhs| (*n).checked_div(rhs).map(Value::from))
            .unwrap_or_else(|| {
                self.promote();
                dispatch_operation!(self, rhs, n, |rhs| Value::from(*n / rhs))
            });
    }
}
```

</details>


Thoughts?